### PR TITLE
Total line appearing in the downloaded PDF

### DIFF
--- a/main.6.js
+++ b/main.6.js
@@ -86,8 +86,8 @@ prism.run([
             const { series: plotOptSeries } = queryResult.plotOptions;
 
             if (!totalAsLine) {
-                plotOptSeries.lineWidth = 0.00001;
-                plotOptSeries.states.hover.lineWidth = 0.00001;
+                plotOptSeries.lineWidth = 0.00000;
+                plotOptSeries.states.hover.lineWidth = 0.00000;
                 plotOptSeries.states.hover.lineWidthPlus = 0;
             }
             plotOptSeries.marker.radius = totalPointSize;


### PR DESCRIPTION
Even when 'custom.barcolumnchart.totalAsLine' is set to false